### PR TITLE
fix(cover): include external advisor on master's thesis cover for professional master

### DIFF
--- a/hfutthesis.cls
+++ b/hfutthesis.cls
@@ -2091,7 +2091,7 @@
         \cline{2-2}
         作者姓名：& \hfut@author \\
         \cline{2-2}
-        导师姓名：& \hfut@supervisor@names \\
+        导师姓名：& \hfut@supervisor@names\ifx\hfut@advisor\@empty\else\quad\hfut@advisor@names\fi \\
         \cline{2-2}
         完成时间：& \hfut@date@zh \\
         \cline{2-2}


### PR DESCRIPTION
## Why

For professional master's students, the thesis cover is required to
display both the internal supervisor and the external advisor on the
"导师姓名" row. The current template only renders `supervisor` on the
cover; `advisor` shows up on the inner title page only.

## What

One-line change in the cover block of `hfutthesis.cls`:

```diff
-导师姓名：& \hfut@supervisor@names \\
+导师姓名：& \hfut@supervisor@names\ifx\hfut@advisor\@empty\else\quad\hfut@advisor@names\fi \\
